### PR TITLE
added event descriptions to `kftools.snirf.eeg.load_snirf_eeg()`

### DIFF
--- a/kftools/snirf/eeg.py
+++ b/kftools/snirf/eeg.py
@@ -79,7 +79,7 @@ def load_snirf_eeg(f, sfreq=1000, epochs=True, tmin=0, tmax=20):
     raw_intensity = read_raw_snirf(f, preload=True)
     events, event_dict = mne.events_from_annotations(raw_intensity)
     my_annot = mne.annotations_from_events(events, sfreq)
-    raw_eeg.set_annotations(my_annot)
+    raw_eeg.set_annotations(my_annot, event_dict)
 
 
 


### PR DESCRIPTION
- **previously**: when setting the annotations, it only used the events array that includes integer indices
- **resulting problem**: it only reported integer indices for annotated events in the loaded raw/epoch object.
- **fix**: added event descriptions to fix this issue.
- now the raw or epoch objects from this function have the event descriptions associated as well